### PR TITLE
[fix] adjust literal parsing an tests

### DIFF
--- a/scripts/validate_literals.sh
+++ b/scripts/validate_literals.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Validate SQL literal patterns against MySQL, PostgreSQL, and SingleStore.
+# Produces a markdown table showing which patterns each database accepts.
+#
+# Prerequisites:
+#   mysql -u ubuntu                          (MySQL on default socket)
+#   psql                                     (PostgreSQL on default socket)
+#   mysql -u root -ptest -h 127.0.0.1 -P 3307  (SingleStore in Docker)
+
+set -o pipefail
+
+run_mysql()       { mysql -u ubuntu -N -e "$1" 2>/dev/null; }
+run_postgres()    { psql -t -A -c "$1" 2>/dev/null; }
+run_singlestore() { mysql -u root -ptest -h 127.0.0.1 -P 3307 -N -e "$1" 2>/dev/null; }
+
+check() {
+    local fn="$1"
+    local sql="$2"
+    if $fn "$sql" >/dev/null 2>&1; then
+        echo -n "yes"
+    else
+        echo -n "no"
+    fi
+}
+
+# Each row: description | SQL to execute
+patterns=(
+    "backslash-escaped single quote \\\\' |SELECT '\\''"
+    "double-escaped single quote ''      |SELECT 'a''b'"
+    "backslash-escaped double quote \\\\\"  |SELECT \"\\\"\""
+    "double-escaped double quote \"\"     |SELECT \"a\"\"b\""
+    "n'string'                            |SELECT n'test'"
+    "N'string'                            |SELECT N'test'"
+    "_utf8'string'                        |SELECT _utf8'test'"
+    "_utf8mb4'string'                     |SELECT _utf8mb4'test'"
+    "_latin1'string'                      |SELECT _latin1'test'"
+    "_binary'string'                      |SELECT _binary'test'"
+    "E'string'                            |SELECT E'test'"
+    "E'backslash escape'                  |SELECT E'it\\'s'"
+    "0x hex number                        |SELECT 0x1f"
+    "X'hex'                               |SELECT X'1f'"
+    "x'hex'                               |SELECT x'1f'"
+    "0b binary number                     |SELECT 0b01"
+    "B'binary'                            |SELECT B'01'"
+    "b'binary'                            |SELECT b'01'"
+    "# line comment                       |SELECT 1 # comment"
+    "-- line comment                      |SELECT 1 -- comment"
+    "/* block comment */                  |SELECT 1 /* comment */"
+    "? placeholder                        |PREPARE s FROM 'SELECT ?'"
+)
+
+printf "| %-42s | %-7s | %-10s | %-12s |\n" "Pattern" "MySQL" "PostgreSQL" "SingleStore"
+printf "|%-44s|%-9s|%-12s|%-14s|\n" "$(printf '%0.s-' {1..44})" "$(printf '%0.s-' {1..9})" "$(printf '%0.s-' {1..12})" "$(printf '%0.s-' {1..14})"
+
+for entry in "${patterns[@]}"; do
+    label="${entry%%|*}"
+    sql="${entry##*|}"
+    label="$(echo "$label" | sed 's/[[:space:]]*$//')"
+    
+    m=$(check run_mysql "$sql")
+    p=$(check run_postgres "$sql")
+    s=$(check run_singlestore "$sql")
+    
+    printf "| %-42s | %-7s | %-10s | %-12s |\n" "$label" "$m" "$p" "$s"
+done

--- a/tokenize.go
+++ b/tokenize.go
@@ -69,8 +69,11 @@ type Config struct {
 	// NoticeUAmpPrefix U& utf prefix U&"\0441\043B\043E\043D" (PostgreSQL)
 	NoticeUAmpPrefix bool
 
-	// NoticeCharsetLiteral _latin1'string' n'string' (MySQL)
+	// NoticeCharsetLiteral _latin1'string' (MySQL, SingleStore)
 	NoticeCharsetLiteral bool
+
+	// NoticeNationalPrefix n'string' N'string' (MySQL)
+	NoticeNationalPrefix bool
 
 	// NoticeNotionalStrings [nN]'...''...' (Oracle, SQL Server)
 	NoticeNotionalStrings bool
@@ -158,9 +161,15 @@ func (c Config) WithNoticeUAmpPrefix() Config {
 	return c
 }
 
-// WithNoticeCharsetLiteral enables charset literal parsing (_latin1'string') using the Literal token (MySQL)
+// WithNoticeCharsetLiteral enables charset literal parsing (_latin1'string') using the Literal token (MySQL, SingleStore)
 func (c Config) WithNoticeCharsetLiteral() Config {
 	c.NoticeCharsetLiteral = true
+	return c
+}
+
+// WithNoticeNationalPrefix enables national string prefix parsing (n'string' N'string') using the Literal token (MySQL)
+func (c Config) WithNoticeNationalPrefix() Config {
+	c.NoticeNationalPrefix = true
 	return c
 }
 
@@ -249,9 +258,22 @@ func SQLServerConfig() Config {
 		WithNoticeIdentifiers()
 }
 
-// MySQL returns a parsing configuration that is appropriate
-// for parsing MySQL, MariaDB.
+// MySQLConfig returns a parsing configuration that is appropriate
+// for parsing MySQL and MariaDB SQL.
 func MySQLConfig() Config {
+	return Config{}.
+		WithNoticeQuestionMark().
+		WithNoticeHashComment().
+		WithNoticeHexNumbers().
+		WithNoticeBinaryNumbers().
+		WithNoticeCharsetLiteral().
+		WithNoticeNationalPrefix().
+		WithNoticeLiteralBackslashEscape()
+}
+
+// SingleStoreConfig returns a parsing configuration that is appropriate
+// for parsing SingleStore SQL.
+func SingleStoreConfig() Config {
 	return Config{}.
 		WithNoticeQuestionMark().
 		WithNoticeHashComment().
@@ -262,24 +284,14 @@ func MySQLConfig() Config {
 		WithNoticeEscapedStrings()
 }
 
-// SingleStore is almost the same as MySQL but it doesn't support notional strings
-func SingleStoreConfig() Config {
-	return Config{}.
-		WithNoticeQuestionMark().
-		WithNoticeHashComment().
-		WithNoticeHexNumbers().
-		WithNoticeBinaryNumbers().
-		WithNoticeLiteralBackslashEscape().
-		WithNoticeEscapedStrings()
-}
-
-// PostgreSQL returns a parsing configuration that is appropriate
+// PostgreSQLConfig returns a parsing configuration that is appropriate
 // for parsing PostgreSQL and CockroachDB SQL.
 func PostgreSQLConfig() Config {
 	return Config{}.
 		WithNoticeDollarNumber().
 		WithNoticeDollarQuotes().
 		WithNoticeUAmpPrefix().
+		WithNoticeNationalPrefix().
 		WithNoticeEscapedStrings()
 }
 
@@ -291,7 +303,7 @@ func TokenizeMySQL(s string) Tokens {
 
 // TokenizeSingleStore breaks up SingleStore SQL strings into
 // Token objects.
-func TokenizeMySQL(s string) Tokens {
+func TokenizeSingleStore(s string) Tokens {
 	return Tokenize(s, SingleStoreConfig())
 }
 
@@ -631,17 +643,19 @@ Word:
 			token(Word)
 			goto BaseState
 		case '\'':
-			if config.NoticeCharsetLiteral {
-				switch s[tokenStart] {
-				case 'n', 'N':
-					if i-tokenStart == 1 {
-						i++
-						goto SingleQuoteString
-					}
-				case '_':
-					i++
-					goto SingleQuoteString
+			if config.NoticeCharsetLiteral && s[tokenStart] == '_' {
+				i++
+				if config.NoticeLiteralBackslashEscape {
+					goto EscapedSingleQuoteString
 				}
+				goto SingleQuoteString
+			}
+			if config.NoticeNationalPrefix && (s[tokenStart] == 'n' || s[tokenStart] == 'N') && i-tokenStart == 1 {
+				i++
+				if config.NoticeLiteralBackslashEscape {
+					goto EscapedSingleQuoteString
+				}
+				goto SingleQuoteString
 			}
 		}
 		r, w := utf8.DecodeRuneInString(s[i:])

--- a/tokenize_test.go
+++ b/tokenize_test.go
@@ -571,18 +571,6 @@ var commonMySQLS2Cases = []Tokens{
 		{Type: Literal, Text: "';\\''"},
 	},
 	{
-		{Type: Word, Text: "m27a"},
-		{Type: Whitespace, Text: " "},
-		{Type: Literal, Text: "e'foo\\'bar'"},
-		{Type: Whitespace, Text: " "},
-	},
-	{
-		{Type: Word, Text: "m27b"},
-		{Type: Whitespace, Text: " "},
-		{Type: Literal, Text: "E'foo\\'bar'"},
-		{Type: Whitespace, Text: " "},
-	},
-	{
 		{Type: Word, Text: "m28"},
 		{Type: Whitespace, Text: " "},
 		{Type: Punctuation, Text: "-"},
@@ -622,6 +610,21 @@ var commonMySQLS2Cases = []Tokens{
 
 var mySQLCases = []Tokens{
 	{
+		// MySQL does not support E'...' prefix — E is a plain word
+		{Type: Word, Text: "m27a"},
+		{Type: Whitespace, Text: " "},
+		{Type: Word, Text: "e"},
+		{Type: Literal, Text: "'foo\\'bar'"},
+		{Type: Whitespace, Text: " "},
+	},
+	{
+		{Type: Word, Text: "m27b"},
+		{Type: Whitespace, Text: " "},
+		{Type: Word, Text: "E"},
+		{Type: Literal, Text: "'foo\\'bar'"},
+		{Type: Whitespace, Text: " "},
+	},
+	{
 		{Type: Word, Text: "m14"},
 		{Type: Whitespace, Text: " "},
 		{Type: Literal, Text: "n'national charset'"},
@@ -648,11 +651,10 @@ var singleStoreCases = []Tokens{
 		{Type: Literal, Text: "'national charset'"},
 	},
 	{
-		// no support for charset prefix for literals
+		// _charset prefix IS supported by SingleStore
 		{Type: Word, Text: "m14"},
 		{Type: Whitespace, Text: " "},
-		{Type: Word, Text: "_utf8"},
-		{Type: Literal, Text: "'redundent'"},
+		{Type: Literal, Text: "_utf8'redundent'"},
 	},
 	{
 		// no support for n prefix for literals
@@ -660,6 +662,19 @@ var singleStoreCases = []Tokens{
 		{Type: Whitespace, Text: " "},
 		{Type: Word, Text: "n"},
 		{Type: Literal, Text: "'martha''s family'"},
+		{Type: Whitespace, Text: " "},
+	},
+	{
+		// SingleStore supports E'...' prefix (unlike MySQL)
+		{Type: Word, Text: "s01"},
+		{Type: Whitespace, Text: " "},
+		{Type: Literal, Text: "E'foo\\'bar'"},
+		{Type: Whitespace, Text: " "},
+	},
+	{
+		{Type: Word, Text: "s02"},
+		{Type: Whitespace, Text: " "},
+		{Type: Literal, Text: "e'foo\\'bar'"},
 		{Type: Whitespace, Text: " "},
 	},
 }
@@ -780,10 +795,10 @@ var postgreSQLCases = []Tokens{
 		{Type: Whitespace, Text: " "},
 	},
 	{
+		// PostgreSQL accepts n'...' as a national string literal
 		{Type: Word, Text: "p16"},
 		{Type: Whitespace, Text: " "},
-		{Type: Word, Text: "n"},
-		{Type: Literal, Text: "'mysql only'"},
+		{Type: Literal, Text: "n'mysql only'"},
 	},
 	{
 		{Type: Word, Text: "p16"},
@@ -797,10 +812,10 @@ var postgreSQLCases = []Tokens{
 		{Type: Punctuation, Text: "=@:?"},
 	},
 	{
+		// PostgreSQL accepts n'...' as a national string literal
 		{Type: Word, Text: "p18"},
 		{Type: Whitespace, Text: " "},
-		{Type: Word, Text: "n"},
-		{Type: Literal, Text: "'martha''s family'"},
+		{Type: Literal, Text: "n'martha''s family'"},
 		{Type: Whitespace, Text: " "},
 	},
 	{


### PR DESCRIPTION
This splits SingleStore configuration from MySQL configuration because they're different.
It adjusts configuration parameters for MySQL, PostgreSQL and SingleStore.
Tests are added.
A script to validate behavior is added.
