### PR TITLE
Add SQLiteConfig, NoticeQuestionNumber

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,16 +3,19 @@ package sqltoken
 // Config specifies the behavior of Tokenize as relates to behavior
 // that differs between SQL implementations
 type Config struct {
-	// Tokenize ? as type Question (used by MySQL)
+	// Tokenize ? as type Question (used by MySQL, SQLite)
 	NoticeQuestionMark bool
 
-	// Tokenize $7 as type DollarNumber (PostgreSQL)
+	// Tokenize ?1 as type Question; implies NoticeQuestionMark (used by SQLite)
+	NoticeQuestionNumber bool
+
+	// Tokenize $7 as type DollarNumber (PostgreSQL, SQLite)
 	NoticeDollarNumber bool
 
-	// Tokenize :word as type ColonWord (sqlx, Oracle)
+	// Tokenize :word as type ColonWord (sqlx, Oracle, SQLite)
 	NoticeColonWord bool
 
-	// Tokenize :word with unicode as ColonWord (sqlx)
+	// Tokenize :word with unicode as ColonWord (sqlx, SQlite)
 	ColonWordIncludesUnicode bool
 
 	// Tokenize # as type comment (MySQL)
@@ -55,10 +58,10 @@ type Config struct {
 	// NoticeMoneyConstants $10 $10.32 (SQL Server)
 	NoticeMoneyConstants bool
 
-	// NoticeAtWord @foo (SQL Server)
+	// NoticeAtWord @foo (SQL Server, SQLite)
 	NoticeAtWord bool
 
-	// NoticeAtIdentifiers _baz @fo$o @@b#ar #foo ##b@ar(SQL Server)
+	// NoticeAtIdentifiers _baz @fo$o @@b#ar #foo ##b@ar (SQL Server)
 	NoticeIdentifiers bool
 
 	// SeparatePunctuation prevents merging successive punctuation into a single token
@@ -77,7 +80,14 @@ func (c Config) WithNoticeQuestionMark() Config {
 	return c
 }
 
-// WithNoticeDollarNumber enables parsing dollar parameters ($1) for PostgreSQL using the DollarNumber token
+// WithNoticeQuestionNumber enables parsing question marks followed by a number (?1) for SQLite.
+func (c Config) WithNoticeQuestionNumber() Config {
+	c.NoticeQuestionNumber = true
+	return c
+}
+
+// WithNoticeDollarNumber enables parsing dollar parameters ($1) for PostgreSQL
+// and SQLite using the DollarNumber token
 func (c Config) WithNoticeDollarNumber() Config {
 	c.NoticeDollarNumber = true
 	return c
@@ -269,6 +279,19 @@ func PostgreSQLConfig() Config {
 		WithNoticeEscapedStrings()
 }
 
+// SQLiteConfig returns a parsing configuration that is appropriate for parsing
+// SQLite SQL.
+func SQLiteConfig() Config {
+	return Config{}.
+		WithNoticeQuestionNumber().
+		WithNoticeQuestionMark().
+		WithNoticeColonWord().
+		WithColonWordIncludesUnicode().
+		WithNoticeAtWord().
+		WithNoticeDollarNumber()
+
+}
+
 // TokenizeMySQL breaks up MySQL / MariaDB strings into
 // Token objects.
 func TokenizeMySQL(s string) Tokens {
@@ -285,4 +308,9 @@ func TokenizeSingleStore(s string) Tokens {
 // Token objects.
 func TokenizePostgreSQL(s string) Tokens {
 	return Tokenize(s, PostgreSQLConfig())
+}
+
+// TokenizeSQLite breaks up SQLite strings into Token objects.
+func TokenizeSQLite(s string) Tokens {
+	return Tokenize(s, SQLiteConfig())
 }

--- a/tokenize.go
+++ b/tokenize.go
@@ -14,13 +14,13 @@ type TokenType int
 const (
 	Comment            TokenType = iota // 0
 	Whitespace                          // 1
-	QuestionMark                        // 2, used in MySQL substitution
+	QuestionMark                        // 2, used in MySQL and SQLite substitution
 	AtSign                              // 3, used in sqlserver substitution
-	DollarNumber                        // 4, used in PostgreSQL substitution
+	DollarNumber                        // 4, used in PostgreSQL and SQLite substitution
 	ColonWord                           // 5, used in sqlx substitution
 	Literal                             // 6, strings
 	Identifier                          // 7, used in SQL Server for many things
-	AtWord                              // 8, used in SQL Server, subset of Identifier
+	AtWord                              // 8, used in SQL Server and SQLite, subset of Identifier
 	Number                              // 9
 	Delimiter                           // 10, semicolon except for MySQL when DELIMITER is used
 	Punctuation                         // 11
@@ -146,6 +146,9 @@ BaseState:
 				token(Delimiter)
 			}
 		case '?':
+			if config.NoticeQuestionNumber {
+				goto QuestionMark
+			}
 			if config.NoticeQuestionMark {
 				token(QuestionMark)
 			} else {
@@ -1270,6 +1273,33 @@ DeliminatedStringRune:
 		}
 	}
 	token(Literal)
+	goto Done
+
+QuestionMark:
+	if i < stop {
+		c := s[i]
+		switch c {
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			i++
+			for i < stop {
+				c := s[i]
+				i++
+				switch c {
+				case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+					continue
+				}
+				i--
+				break
+			}
+			token(QuestionMark)
+			goto BaseState
+		}
+		// ?
+		token(QuestionMark)
+		goto BaseState
+	}
+	// ?
+	token(QuestionMark)
 	goto Done
 
 Dollar:

--- a/tokenize_test.go
+++ b/tokenize_test.go
@@ -923,6 +923,18 @@ var commonMySQLS2Cases = []Tokens{
 		{Type: Delimiter, Text: "\"59"},
 		{Type: Whitespace, Text: "\n"},
 	},
+	{
+		{Type: Word, Text: "select"},
+		{Type: Whitespace, Text: " "},
+		{Type: QuestionMark, Text: "?"},
+		{Type: Punctuation, Text: ","},
+		{Type: Whitespace, Text: " "},
+		{Type: QuestionMark, Text: "?"},
+		{Type: Number, Text: "1"},
+		{Type: Punctuation, Text: ","},
+		{Type: Whitespace, Text: " "},
+		{Type: QuestionMark, Text: "?"},
+	},
 }
 
 var mySQLCases = []Tokens{
@@ -1256,6 +1268,38 @@ var postgreSQLCases = []Tokens{
 	},
 }
 
+var sqliteCases = []Tokens{
+	{
+		{Type: Word, Text: "select"},
+		{Type: Whitespace, Text: " "},
+		{Type: QuestionMark, Text: "?"},
+		{Type: Punctuation, Text: ","},
+		{Type: Whitespace, Text: " "},
+		{Type: QuestionMark, Text: "?1"},
+		{Type: Punctuation, Text: ","},
+		{Type: Whitespace, Text: " "},
+		{Type: QuestionMark, Text: "?"},
+	},
+	{
+		{Type: Word, Text: "select"},
+		{Type: Whitespace, Text: " "},
+		{Type: QuestionMark, Text: "?"},
+		{Type: Punctuation, Text: ","},
+		{Type: Whitespace, Text: " "},
+		{Type: QuestionMark, Text: "?123"},
+		{Type: Punctuation, Text: ","},
+		{Type: Whitespace, Text: " "},
+		{Type: ColonWord, Text: ":one"},
+		{Type: Punctuation, Text: ","},
+		{Type: Whitespace, Text: " "},
+		{Type: AtWord, Text: "@two"},
+		{Type: Punctuation, Text: ","},
+		{Type: Whitespace, Text: " "},
+		{Type: DollarNumber, Text: "$456"},
+		{Type: Whitespace, Text: " "},
+	},
+}
+
 var oracleCases = []Tokens{
 	{
 		{Type: Word, Text: "o1"},
@@ -1565,7 +1609,7 @@ var oddball1Cases = []Tokens{
 	},
 }
 
-// SQLx
+// SQLx, SQLite
 var oddball2Cases = []Tokens{
 	{
 		{Type: Word, Text: "sqlx1"},
@@ -1669,6 +1713,10 @@ func TestSingleStoreTokenizing(t *testing.T) {
 
 func TestPostgresSQLTokenizing(t *testing.T) {
 	doTests(t, "psql_", PostgreSQLConfig(), commonCases, postgreSQLCases)
+}
+
+func TestSQLiteTokenizing(t *testing.T) {
+	doTests(t, "sqlite_", SQLiteConfig(), commonCases, sqliteCases, oddball2Cases)
 }
 
 func TestOracleTokenizing(t *testing.T) {


### PR DESCRIPTION
SQLite looked at the various parameter placeholders different engines use and decided to implement all of them, as well as adding their own "?nnn" syntax. https://sqlite.org/lang_expr.html#varparam

"?nnn" is emitted as Question; I suppose a new token type could be added for it, but this seems okay to use?

AFAIK SQLite doesn't have any other special features.